### PR TITLE
Add concise project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-*
+# Nail Moment Wrocław
+
+Official website for Nail Moment Wrocław, built with Next.js and organized using Feature-Sliced Design.
+
+## Quick start
+
+```bash
+npm install
+npm run dev
+```
+
+## Scripts
+
+- `npm run lint` – run ESLint checks
+- `npm run build` – create a production build
+- `npm run dev` – start local development server


### PR DESCRIPTION
### Motivation
- Replace the placeholder README with a concise project overview and quick-start instructions for local development.

### Description
- Updated `README.md` to include the project title, a one-line description, a `Quick start` section with `npm install` and `npm run dev`, and a short `Scripts` list (`npm run lint`, `npm run build`, `npm run dev`).

### Testing
- Ran `npm run lint` which completed successfully, and ran `npm run build` which failed because Next.js could not fetch Google Fonts from `fonts.googleapis.com` in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e15915bb9c8325bc62ca191ca15838)